### PR TITLE
Support early termination in range

### DIFF
--- a/assert_test.go
+++ b/assert_test.go
@@ -14,8 +14,9 @@ func bitmapWith(c *container) (*Bitmap, []uint16) {
 
 func valuesOf(v *Bitmap) []uint16 {
 	out := []uint16{}
-	v.Range(func(x uint32) {
+	v.Range(func(x uint32) bool {
 		out = append(out, uint16(x))
+		return true
 	})
 	return out
 }

--- a/assert_test.go
+++ b/assert_test.go
@@ -25,12 +25,26 @@ func newArr(data ...uint32) *container {
 	return newContainer(typeArray, data...)
 }
 
+func newRun(data ...uint32) *container {
+	return newContainer(typeRun, data...)
+}
+
 func newBmp(data ...uint32) *container {
 	return newContainer(typeBitmap, data...)
 }
 
-func newRun(data ...uint32) *container {
-	return newContainer(typeRun, data...)
+// newBmpPermutations creates a Bitmap with all 16 4-bit permutations
+func newBmpPermutations() *container {
+	rb := newBmp()
+	for perm := 0; perm < 16; perm++ {
+		offset := perm * 4
+		for bit := 0; bit < 4; bit++ {
+			if (perm>>bit)&1 == 1 {
+				rb.bmpSet(uint16(offset + bit))
+			}
+		}
+	}
+	return rb
 }
 
 func newContainer(typ ctype, data ...uint32) *container {

--- a/codec_test.go
+++ b/codec_test.go
@@ -31,8 +31,8 @@ func bitmapsEqual(t *testing.T, a, b *Bitmap) {
 	t.Helper()
 	assert.Equal(t, a.Count(), b.Count(), "Count mismatch")
 	var av, bv []uint32
-	a.Range(func(x uint32) { av = append(av, x) })
-	b.Range(func(x uint32) { bv = append(bv, x) })
+	a.Range(func(x uint32) bool { av = append(av, x); return true })
+	b.Range(func(x uint32) bool { bv = append(bv, x); return true })
 	assert.Equal(t, av, bv, "Values mismatch")
 }
 

--- a/range.go
+++ b/range.go
@@ -16,9 +16,11 @@ func (rb *Bitmap) Range(fn func(x uint32) bool) {
 			}
 
 		case typeBitmap:
-			c.bmpRange(func(value uint32) bool {
+			if !c.bmpRange(func(value uint32) bool {
 				return fn(base | value)
-			})
+			}) {
+				return
+			}
 
 		case typeRun:
 			numRuns := len(c.Data) / 2
@@ -91,7 +93,7 @@ func (rb *Bitmap) Filter(f func(x uint32) bool) {
 }
 
 // Iterate iterates over all of the bits set to one in this bitmap.
-func (c *container) bmpRange(fn func(x uint32) bool) {
+func (c *container) bmpRange(fn func(x uint32) bool) bool {
 	dst := c.bmp()
 	for blkAt := 0; blkAt < len(dst); blkAt++ {
 		blk := dst[blkAt]
@@ -106,117 +108,118 @@ func (c *container) bmpRange(fn func(x uint32) bool) {
 			switch blk & 0b1111 {
 			case 0b0001:
 				if !fn(offset + 0) {
-					return
+					return false
 				}
 			case 0b0010:
 				if !fn(offset + 1) {
-					return
+					return false
 				}
 			case 0b0011:
 				if !fn(offset + 0) {
-					return
+					return false
 				}
 				if !fn(offset + 1) {
-					return
+					return false
 				}
 			case 0b0100:
 				if !fn(offset + 2) {
-					return
+					return false
 				}
 			case 0b0101:
 				if !fn(offset + 0) {
-					return
+					return false
 				}
 				if !fn(offset + 2) {
-					return
+					return false
 				}
 			case 0b0110:
 				if !fn(offset + 1) {
-					return
+					return false
 				}
 				if !fn(offset + 2) {
-					return
+					return false
 				}
 			case 0b0111:
 				if !fn(offset + 0) {
-					return
+					return false
 				}
 				if !fn(offset + 1) {
-					return
+					return false
 				}
 				if !fn(offset + 2) {
-					return
+					return false
 				}
 			case 0b1000:
 				if !fn(offset + 3) {
-					return
+					return false
 				}
 			case 0b1001:
 				if !fn(offset + 0) {
-					return
+					return false
 				}
 				if !fn(offset + 3) {
-					return
+					return false
 				}
 			case 0b1010:
 				if !fn(offset + 1) {
-					return
+					return false
 				}
 				if !fn(offset + 3) {
-					return
+					return false
 				}
 			case 0b1011:
 				if !fn(offset + 0) {
-					return
+					return false
 				}
 				if !fn(offset + 1) {
-					return
+					return false
 				}
 				if !fn(offset + 3) {
-					return
+					return false
 				}
 			case 0b1100:
 				if !fn(offset + 2) {
-					return
+					return false
 				}
 				if !fn(offset + 3) {
-					return
+					return false
 				}
 			case 0b1101:
 				if !fn(offset + 0) {
-					return
+					return false
 				}
 				if !fn(offset + 2) {
-					return
+					return false
 				}
 				if !fn(offset + 3) {
-					return
+					return false
 				}
 			case 0b1110:
 				if !fn(offset + 1) {
-					return
+					return false
 				}
 				if !fn(offset + 2) {
-					return
+					return false
 				}
 				if !fn(offset + 3) {
-					return
+					return false
 				}
 			case 0b1111:
 				if !fn(offset + 0) {
-					return
+					return false
 				}
 				if !fn(offset + 1) {
-					return
+					return false
 				}
 				if !fn(offset + 2) {
-					return
+					return false
 				}
 				if !fn(offset + 3) {
-					return
+					return false
 				}
 			}
 			offset += 4
 		}
 	}
+	return true
 }

--- a/range_test.go
+++ b/range_test.go
@@ -404,3 +404,22 @@ func TestEdgeCases(t *testing.T) {
 		}
 	})
 }
+
+func TestRangeStop(t *testing.T) {
+	rb := New()
+	rb.ctrAdd(0, 0, newBmpPermutations())
+
+	var count int
+	for i := 1; i < 64; i++ {
+		rb.Range(func(x uint32) bool {
+			if x >= uint32(i) {
+				count++
+				return false
+			}
+
+			return true
+		})
+	}
+
+	assert.Equal(t, 63, count)
+}

--- a/range_test.go
+++ b/range_test.go
@@ -29,7 +29,7 @@ func TestRange(t *testing.T) {
 
 			// Test Range output matches reference
 			var ourValues, refValues []uint32
-			our.Range(func(x uint32) { ourValues = append(ourValues, x) })
+			our.Range(func(x uint32) bool { ourValues = append(ourValues, x); return true })
 			ref.Range(func(x uint32) { refValues = append(refValues, x) })
 
 			assert.Equal(t, refValues, ourValues)
@@ -204,8 +204,9 @@ func TestFilter(t *testing.T) {
 		assert.False(t, rb.Contains(3)) // 3 % 5 != 0
 
 		// Verify all remaining values pass the predicate
-		rb.Range(func(x uint32) {
+		rb.Range(func(x uint32) bool {
 			assert.Equal(t, uint32(0), x%5, "Value %d should be divisible by 5", x)
+			return true
 		})
 	})
 
@@ -250,8 +251,9 @@ func TestRangeAndFilterConsistency(t *testing.T) {
 
 		// Use Range to collect remaining values
 		var remaining []uint32
-		rb.Range(func(x uint32) {
+		rb.Range(func(x uint32) bool {
 			remaining = append(remaining, x)
+			return true
 		})
 
 		// Sort both slices for comparison
@@ -285,8 +287,9 @@ func TestRangeAndFilterConsistency(t *testing.T) {
 		// Should have numbers divisible by 4: 4, 8, 12, 16, ..., 100
 		assert.Equal(t, 25, rb.Count()) // 100/4 = 25
 
-		rb.Range(func(x uint32) {
+		rb.Range(func(x uint32) bool {
 			assert.Equal(t, uint32(0), x%4, "Value %d should be divisible by 4", x)
+			return true
 		})
 	})
 }
@@ -318,7 +321,7 @@ func TestContainerTypes(t *testing.T) {
 
 			// Test Range
 			var result []uint32
-			our.Range(func(x uint32) { result = append(result, x) })
+			our.Range(func(x uint32) bool { result = append(result, x); return true })
 			assert.Equal(t, values, result)
 		})
 	}
@@ -333,7 +336,7 @@ func TestEdgeCases(t *testing.T) {
 		assert.Equal(t, 0, rb.Count())
 
 		var values []uint32
-		rb.Range(func(x uint32) { values = append(values, x) })
+		rb.Range(func(x uint32) bool { values = append(values, x); return true })
 		assert.Empty(t, values)
 	})
 
@@ -364,7 +367,7 @@ func TestEdgeCases(t *testing.T) {
 
 		// Test range maintains order
 		var result []uint32
-		rb.Range(func(x uint32) { result = append(result, x) })
+		rb.Range(func(x uint32) bool { result = append(result, x); return true })
 		assert.Equal(t, boundaries, result)
 	})
 


### PR DESCRIPTION
This pull request introduces a significant update to the `Range` method in the `Bitmap` class, enhancing its functionality by allowing early termination of iteration. Additionally, it includes optimizations for bitmap traversal and updates to related test cases to ensure consistency and correctness.

### Enhancements to `Range` method:

* Modified the `Range` method in `Bitmap` to accept a callback function that returns a `bool`, enabling early termination of the iteration when `false` is returned. (`range.go`, [range.goL4-R4](diffhunk://#diff-e11ce490603e94d9a19bd46b0dbce0cc263a7bb9317bb5d71600f62958633bafL4-R4))
* Updated the `Range` implementation to handle different container types (`typeArray`, `typeBitmap`, `typeRun`) with the new callback behavior. (`range.go`, [range.goL13-R33](diffhunk://#diff-e11ce490603e94d9a19bd46b0dbce0cc263a7bb9317bb5d71600f62958633bafL13-R33))

### Optimizations for bitmap traversal:

* Added the `bmpRange` method to optimize bitmap traversal by iterating in 4-bit chunks, reducing function calls and improving performance. (`range.go`, [range.goR94-R225](diffhunk://#diff-e11ce490603e94d9a19bd46b0dbce0cc263a7bb9317bb5d71600f62958633bafR94-R225))

### Updates to test cases:

* Updated all test cases using `Range` to accommodate the new callback signature, ensuring correctness and compatibility. (`assert_test.go`, [[1]](diffhunk://#diff-cc012cf4bc0e45c461f4aed072f95d1fcc2e597e76f03c7416ae51e55f4c0315L17-R19); `codec_test.go`, [[2]](diffhunk://#diff-4b538c884e20ff2bb5c787cbf8633df6189db1fdbb6f02ef9ec3c42b52e9d3aaL34-R35); `range_test.go`, [[3]](diffhunk://#diff-6b33921f7d7c65942a4f9b7471f9be358f4fbfe420a0f7a414e01fdc9b3917e8L32-R32) [[4]](diffhunk://#diff-6b33921f7d7c65942a4f9b7471f9be358f4fbfe420a0f7a414e01fdc9b3917e8L207-R209) [[5]](diffhunk://#diff-6b33921f7d7c65942a4f9b7471f9be358f4fbfe420a0f7a414e01fdc9b3917e8L253-R256) [[6]](diffhunk://#diff-6b33921f7d7c65942a4f9b7471f9be358f4fbfe420a0f7a414e01fdc9b3917e8L288-R292) [[7]](diffhunk://#diff-6b33921f7d7c65942a4f9b7471f9be358f4fbfe420a0f7a414e01fdc9b3917e8L321-R324) [[8]](diffhunk://#diff-6b33921f7d7c65942a4f9b7471f9be358f4fbfe420a0f7a414e01fdc9b3917e8L336-R339) [[9]](diffhunk://#diff-6b33921f7d7c65942a4f9b7471f9be358f4fbfe420a0f7a414e01fdc9b3917e8L367-R370)
* Added a new test case, `TestRangeStop`, to validate the early termination functionality of the `Range` method. (`range_test.go`, [range_test.goR407-R425](diffhunk://#diff-6b33921f7d7c65942a4f9b7471f9be358f4fbfe420a0f7a414e01fdc9b3917e8R407-R425))

These changes improve the flexibility and efficiency of bitmap operations while ensuring robust testing coverage.