### PR TITLE
Enhance bitmap codec with endian-aware serialization and new benchmarks

### DIFF
--- a/codec_test.go
+++ b/codec_test.go
@@ -13,20 +13,26 @@ import (
 
 func makeTestBitmap() *Bitmap {
 	rb := New()
+
 	// Array container
 	rb.Set(1)
 	rb.Set(5)
 	rb.Set(10)
+
 	// Bitmap container
-	for i := 65536; i < 65536+5000; i += 3 {
+	for i := 0xFFFF; i < 0xFFFF+0x5FFF; i += 3 {
 		rb.Set(uint32(i))
 	}
+
 	// Run container
-	for i := 131072; i < 131072+100; i++ {
+	for i := 131072; i < 131072+1000; i++ {
 		rb.Set(uint32(i))
 	}
+
 	// Max uint32
 	rb.Set(4294967295)
+
+	rb.Optimize()
 	return rb
 }
 
@@ -102,4 +108,24 @@ func TestCodec_SparseRandom(t *testing.T) {
 	data := rb.ToBytes()
 	rb2 := FromBytes(data)
 	bitmapsEqual(t, rb, rb2)
+}
+
+func TestCodec_BigEndian(t *testing.T) {
+	data := []uint16{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+
+	var buf1 bytes.Buffer
+	assert.NoError(t, writeUint16s(&buf1, true, data))
+
+	var buf2 bytes.Buffer
+	assert.NoError(t, writeUint16s(&buf2, false, data))
+
+	assert.Equal(t, buf1.Bytes(), buf2.Bytes())
+
+	out1, err := readUint16s(&buf1, true, len(data)*2)
+	assert.NoError(t, err)
+	assert.Equal(t, data, out1)
+
+	out2, err := readUint16s(&buf2, false, len(data)*2)
+	assert.NoError(t, err)
+	assert.Equal(t, data, out2)
 }


### PR DESCRIPTION
This pull request introduces enhancements to the benchmarking suite and optimizes codec operations for better performance and compatibility with both little-endian and big-endian architectures. The most significant changes include adding a new codec benchmark, implementing endian-aware read/write methods, and extending test coverage for codec operations.

```
name                 time/op      ops/s        allocs/op    vs prev          
-------------------- ------------ ------------ ------------ ------------------
write seq            154.2 ns     6.5M         9            ✅ +17% (p=0.000)
write rnd            2.7 µs       366.0K       11           ✅ +543% (p=0.000)
write sps            132.3 µs     7.6K         4.6K         ✅ +172% (p=0.000)
write dns            982.4 ns     1.0M         7            ✅ +764% (p=0.000)

name                 time/op      ops/s        allocs/op    vs prev            
-------------------- ------------ ------------ ------------ ------------------ 
read seq             224.9 ns     4.4M         13           ✅ +19% (p=0.000)
read rnd             4.7 µs       210.7K       13           ✅ +311% (p=0.000)
read sps             134.2 µs     7.5K         6.1K         ✅ +162% (p=0.000)
read dns             2.4 µs       413.6K       8            ✅ +305% (p=0.000)
```


### Benchmarking Enhancements:
* [`bench/main.go`](diffhunk://#diff-66d31465380baa81993389a9dbd5883ba03af66e934c179b54a16636a54abecfR23-R26): Added a new `runCodec` function to benchmark `WriteTo` and `ReadFrom` operations for 100K bitmaps with various shapes (sequential, random, sparse, dense). Updated the benchmarking configuration to increase sample size from 100 to 200. [[1]](diffhunk://#diff-66d31465380baa81993389a9dbd5883ba03af66e934c179b54a16636a54abecfR23-R26) [[2]](diffhunk://#diff-66d31465380baa81993389a9dbd5883ba03af66e934c179b54a16636a54abecfR191-R223)

### Codec Optimizations:
* [`codec.go`](diffhunk://#diff-4eb56050e99b061354bcb7073c73882f046a1f06dd967e0d72b81a690c8ce3d4R11-R15): Introduced `writeUint16s` and `readUint16s` methods to handle endian-aware serialization and deserialization of `uint16` slices. These methods use the `unsafe` package for efficient memory operations on little-endian systems. [[1]](diffhunk://#diff-4eb56050e99b061354bcb7073c73882f046a1f06dd967e0d72b81a690c8ce3d4R11-R15) [[2]](diffhunk://#diff-4eb56050e99b061354bcb7073c73882f046a1f06dd967e0d72b81a690c8ce3d4R176-R204)
* [`codec.go`](diffhunk://#diff-4eb56050e99b061354bcb7073c73882f046a1f06dd967e0d72b81a690c8ce3d4L73-R76): Updated `WriteTo` and `ReadFrom` methods to utilize the new endian-aware methods for improved compatibility and performance. [[1]](diffhunk://#diff-4eb56050e99b061354bcb7073c73882f046a1f06dd967e0d72b81a690c8ce3d4L73-R76) [[2]](diffhunk://#diff-4eb56050e99b061354bcb7073c73882f046a1f06dd967e0d72b81a690c8ce3d4L112-R116)

### Test Suite Improvements:
* [`codec_test.go`](diffhunk://#diff-4b538c884e20ff2bb5c787cbf8633df6189db1fdbb6f02ef9ec3c42b52e9d3aaR16-R35): Added a new test, `TestCodec_BigEndian`, to verify the correctness of `writeUint16s` and `readUint16s` methods on both little-endian and big-endian systems. Extended the test bitmap to include additional ranges and optimized its structure. [[1]](diffhunk://#diff-4b538c884e20ff2bb5c787cbf8633df6189db1fdbb6f02ef9ec3c42b52e9d3aaR16-R35) [[2]](diffhunk://#diff-4b538c884e20ff2bb5c787cbf8633df6189db1fdbb6f02ef9ec3c42b52e9d3aaR112-R131)